### PR TITLE
add regval proc

### DIFF
--- a/scripts/trace.tcl
+++ b/scripts/trace.tcl
@@ -1029,6 +1029,17 @@ proc get_num_external_trigger_inputs {} {
     return $result
 }
 
+# Surprisingly, Jim Tcl lacks a primitive that returns the value of a
+# register.  It only exposes a "cooked" line of output suitable for
+# display.  But we can use that to extract the actual register value
+# and return it
+proc regval {name} {
+	set displayval [ocd_reg $name]
+	set splitval [split $displayval ':']
+	set val [lindex $splitval 1]
+	return [string trim $val]
+}
+
 
 mww $te_control 0x01830001
 mww $te_sinkrp 0xffffffff


### PR DESCRIPTION
Surprisingly, Jim Tcl doesn't have a routine that returns the value of a named register (not a memory mapped register but a GPR or CSR).  But it returns a cooked display string from which the actual value can be derived.  So, adding a routine that derives and returns a GPR or CSR value from a supported named register.  Freedom Studio will use this (via socket) to access the trigger-related CSRs.