### PR TITLE
add routines that enable/disable trace without any other side effects

### DIFF
--- a/scripts/trace.tcl
+++ b/scripts/trace.tcl
@@ -169,6 +169,47 @@ proc ite {} {
     return 0
 }
 
+proc enable_trace_lite {} {
+    global te_control_offset
+    global traceBaseAddresses
+    global traceFunnelAddress
+
+    foreach baseAddress $traceBaseAddresses {
+	set addr [expr $baseAddress + $te_control_offset]
+	set tracectl [word $addr]
+	mww $addr [expr $tracectl | 0x7]
+    }
+
+    if {$traceFunnelAddress != 0} {
+	set addr [expr $traceFunnelAddress + $te_control_offset]
+	set tracectl [word $addr]
+	mww $addr [expr $tracectl | 0x7]
+    }
+
+    return 0
+}
+
+proc disable_trace_lite {} {
+    global te_control_offset
+    global traceBaseAddresses
+    global traceFunnelAddress
+
+    foreach baseAddress $traceBaseAddresses {
+	set addr [expr $baseAddress + $te_control_offset]
+	set tracectl [word $addr]
+	mww $addr [expr $tracectl & ~0x6]
+    }
+
+    if {$traceFunnelAddress != 0} {
+	set addr [expr $traceFunnelAddress + $te_control_offset]
+	set tracectl [word $addr]
+	mww $addr [expr $tracectl & ~0x6]
+    }
+
+    return 0
+}
+
+
 proc setAllTeControls {offset val} {
   global traceBaseAddresses
 


### PR DESCRIPTION
Using "trace on" has side effect of resetting the wp, and I was observing a race condition after capturing trace where FS wants to manipulate some registers that trace.tcl won't allow if tracing is enabled, so FS bracketed the accesses in "trace off" and then "trace on" calls.  But if the trace in the buffer had yet to be offloaded, then the "trace on" would clobber the write pointer before FS called "wtb".    So, my approach for this was to avoid "trace off" and "trace on" for these temporary disabling/reenabling of trace, and instead to use these new "lite" procs for that.   The lite procs just swizzle the teEnable and teTracing bits, and that's all.