### PR TITLE
Itc print tweeks

### DIFF
--- a/include/dqr.hpp
+++ b/include/dqr.hpp
@@ -232,7 +232,7 @@ private:
 class NexusMessage {
 public:
 	NexusMessage();
-	void processITCPrintData(class ITCPrint *itcPrint);
+	bool processITCPrintData(class ITCPrint *itcPrint);
 	void messageToText(char *dst,size_t dst_len,int level);
 	std::string messageToString(int detailLevel);
 	double seconds();

--- a/include/trace.hpp
+++ b/include/trace.hpp
@@ -134,7 +134,7 @@ class ITCPrint {
 public:
 	ITCPrint(int numCores,int buffSize,int channel);
 	~ITCPrint();
-	void print(uint8_t core, uint32_t address, uint32_t data);
+	bool print(uint8_t core, uint32_t address, uint32_t data);
 	void haveITCPrintData(int numMsgs[DQR_MAXCORES], bool havePrintData[DQR_MAXCORES]);
 	bool getITCPrintMsg(uint8_t core, char *dst, int dstLen);
 	bool flushITCPrintMsg(uint8_t core, char *dst, int dstLen);

--- a/makefile.init
+++ b/makefile.init
@@ -31,12 +31,16 @@ ifeq ($(OS),Windows_NT)
     ifeq ($(SWIG),)
         $(info swig not found; skipping swig and dqr shared library build)
         SWIGLIB := 
+        JNIINCLUDEPATHS :=
     else
         ifndef JNIINCLUDE
             $(info JNIINCLUDE not defined; skipping swig and dqr shared library build)
             SWIGLIB :=
+            JNIINCLUDEPATHS :=
         else
             SWIGLIB := dqr.dll
+            $(info building swig $(SWIGLIB))
+            JNIINCLUDEPATHS := -I"$(JNIINCLUDE)" -I"$(JNIINCLUDE)\win32"
         endif
     endif
     CFLAGS += -D WINDOWS -std=c++11
@@ -45,7 +49,6 @@ ifeq ($(OS),Windows_NT)
     LNFLAGS = -static
     LIBS := -lbfd -lopcodes -lintl -liberty -lz
     EXECUTABLE := dqr.exe
-    JNIINCLUDEPATHS := -I"$(JNIINCLUDE)" -I"$(JNIINCLUDE)\win32"
 else
     UNAME_S := $(shell uname -s)
     ifeq ($(UNAME_S),Linux)
@@ -176,12 +179,15 @@ else
         ifeq ($(SWIG),)
             $(info swig not found; skipping swig and dqr shared library build)
             SWIGLIB := 
+            JNIINCLUDEPATHS :=
         else
             ifndef JNIINCLUDE
                 $(info JNIINCLUDE not defined; skipping swig and dqr shared library build)
                 SWIGLIB := 
+                JNIINCLUDEPATHS :=
             else
                 SWIGLIB := libdqr.so
+                JNIINCLUDEPATHS := -I"$(JNIINCLUDE)" -I"$(JNIINCLUDE)/linux"
             endif
         endif
         REDHAT_REL := $(wildcard /etc/redhat-release)
@@ -192,7 +198,6 @@ else
             LIBS := -lbfd -lopcodes -liberty -lz -ldl
             LNFLAGS =
             EXECUTABLE := dqr
-            JNIINCLUDEPATHS := -I"$(JNIINCLUDE)" -I"$(JNIINCLUDE)/linux"
         else
             ifeq ($(CROSSPREFIX),x86_64-w64-mingw32-)
                 PLATFORM := windows
@@ -223,7 +228,6 @@ else
                 LNFLAGS = -static
                 EXECUTABLE := dqr
             endif
-            JNIINCLUDEPATHS := -I"$(JNIINCLUDE)" -I"$(JNIINCLUDE)/linux"
         endif
     endif
     ifeq ($(UNAME_S),Darwin)
@@ -245,12 +249,15 @@ else
         ifeq ($(SWIG),)
             $(info swig not found; skipping swig and dqr shared library build)
             SWIGLIB := 
+            JNIINCLUDEPATHS :=
         else
            ifndef JNIINCLUDE
                 $(info JNIINCLUDE not defined; skipping swig and dqr shared library build)
                 SWIGLIB :=
+                JNIINCLUDEPATHS :=
             else
                 SWIGLIB := libdqr.so
+                JNIINCLUDEPATHS := -I"$(JNIINCLUDE)" -I"$(JNIINCLUDE)/darwin"
             endif
         endif
         CFLAGS += -D OSX -std=c++11
@@ -259,7 +266,6 @@ else
         LIBS := -lbfd -lopcodes -liberty -lz -lintl -liconv
         LNFLAGS =
         EXECUTABLE := dqr
-        JNIINCLUDEPATHS := -I"$(JNIINCLUDE)" -I"$(JNIINCLUDE)/darwin"
     endif
     UNAME_P := $(shell uname -p)
 endif

--- a/src/trace.cpp
+++ b/src/trace.cpp
@@ -813,12 +813,12 @@ TraceDqr::DQErr Trace::NextInstruction(Instruction **instInfo, NexusMessage **ms
 				messageInfo.currentAddress = currentAddress[currentCore];
 				messageInfo.time = lastTime[currentCore];
 
-				messageInfo.processITCPrintData(itcPrint);
+				if (messageInfo.processITCPrintData(itcPrint) == false) {
+					*msgInfo = &messageInfo;
 
-				*msgInfo = &messageInfo;
-
-				status = TraceDqr::DQERR_OK;
-				return status;
+					status = TraceDqr::DQERR_OK;
+					return status;
+				}
 			}
 			break;
 		case TRACE_STATE_GETFIRSTYNCMSG:
@@ -893,9 +893,9 @@ TraceDqr::DQErr Trace::NextInstruction(Instruction **instInfo, NexusMessage **ms
 				messageInfo.currentAddress = currentAddress[currentCore];
 				messageInfo.time = lastTime[currentCore];
 
-				messageInfo.processITCPrintData(itcPrint);
-
-				*msgInfo = &messageInfo;
+				if (messageInfo.processITCPrintData(itcPrint) == false) {
+					*msgInfo = &messageInfo;
+				}
 			}
 
 			status = TraceDqr::DQERR_OK;
@@ -961,9 +961,9 @@ TraceDqr::DQErr Trace::NextInstruction(Instruction **instInfo, NexusMessage **ms
 					messageInfo.time = lastTime[currentCore];
 					messageInfo.currentAddress = currentAddress[currentCore];
 
-					messageInfo.processITCPrintData(itcPrint);
-
-					*msgInfo = &messageInfo;
+					if (messageInfo.processITCPrintData(itcPrint) == false) {
+						*msgInfo = &messageInfo;
+					}
 				}
 
 				readNewTraceMessage = true;
@@ -994,9 +994,9 @@ TraceDqr::DQErr Trace::NextInstruction(Instruction **instInfo, NexusMessage **ms
 					messageInfo.time = lastTime[currentCore];
 					messageInfo.currentAddress = currentAddress[currentCore];
 
-					messageInfo.processITCPrintData(itcPrint);
-
-					*msgInfo = &messageInfo;
+					if (messageInfo.processITCPrintData(itcPrint) == false) {
+						*msgInfo = &messageInfo;
+					}
 				}
 
 				readNewTraceMessage = true;
@@ -1014,9 +1014,9 @@ TraceDqr::DQErr Trace::NextInstruction(Instruction **instInfo, NexusMessage **ms
 					messageInfo.time = lastTime[currentCore];
 					messageInfo.currentAddress = currentAddress[currentCore];
 
-					messageInfo.processITCPrintData(itcPrint);
-
-					*msgInfo = &messageInfo;
+					if (messageInfo.processITCPrintData(itcPrint) == false) {
+						*msgInfo = &messageInfo;
+					}
 				}
 
 				readNewTraceMessage = true;
@@ -1034,9 +1034,9 @@ TraceDqr::DQErr Trace::NextInstruction(Instruction **instInfo, NexusMessage **ms
 					messageInfo.time = lastTime[currentCore];
 					messageInfo.currentAddress = currentAddress[currentCore];
 
-					messageInfo.processITCPrintData(itcPrint);
-
-					*msgInfo = &messageInfo;
+					if (messageInfo.processITCPrintData(itcPrint) == false) {
+						*msgInfo = &messageInfo;
+					}
 				}
 
 				readNewTraceMessage = true;
@@ -1071,9 +1071,9 @@ TraceDqr::DQErr Trace::NextInstruction(Instruction **instInfo, NexusMessage **ms
 						messageInfo.time = lastTime[currentCore];
 						messageInfo.currentAddress = currentAddress[currentCore];
 
-						messageInfo.processITCPrintData(itcPrint);
-
-						*msgInfo = &messageInfo;
+						if (messageInfo.processITCPrintData(itcPrint) == false) {
+							*msgInfo = &messageInfo;
+						}
 					}
 
 					// Do not return info yet. Cycle again untill we fill in
@@ -1104,9 +1104,9 @@ TraceDqr::DQErr Trace::NextInstruction(Instruction **instInfo, NexusMessage **ms
 					messageInfo.time = lastTime[currentCore];
 					messageInfo.currentAddress = currentAddress[currentCore];
 
-					messageInfo.processITCPrintData(itcPrint);
-
-					*msgInfo = &messageInfo;
+					if (messageInfo.processITCPrintData(itcPrint) == false) {
+						*msgInfo = &messageInfo;
+					}
 				}
 
 				readNewTraceMessage = true;
@@ -1128,9 +1128,9 @@ TraceDqr::DQErr Trace::NextInstruction(Instruction **instInfo, NexusMessage **ms
 //					messageInfo.currentAddress = currentAddress;
 					messageInfo.currentAddress = lastFaddr[currentCore] + nm.correlation.i_cnt*2;
 
-					messageInfo.processITCPrintData(itcPrint);
-
-					*msgInfo = &messageInfo;
+					if (messageInfo.processITCPrintData(itcPrint) == false) {
+						*msgInfo = &messageInfo;
+					}
 				}
 
 				readNewTraceMessage = true;
@@ -1208,9 +1208,9 @@ TraceDqr::DQErr Trace::NextInstruction(Instruction **instInfo, NexusMessage **ms
 					messageInfo.time = lastTime[currentCore];
 					messageInfo.currentAddress = currentAddress[currentCore];
 
-					messageInfo.processITCPrintData(itcPrint);
-
-					*msgInfo = &messageInfo;
+					if (messageInfo.processITCPrintData(itcPrint) == false) {
+						*msgInfo = &messageInfo;
+					}
 				}
 
 				// leave state along. Need to get another message with an i-cnt!


### PR DESCRIPTION
Added filtering of data acquisition messages so that if itc prints are being displayed, data acquisition trace messages to the channel for itc print are not returned to the caller of Trace::NextInstruction().